### PR TITLE
Rename unicode csv functions

### DIFF
--- a/karld/loadump.py
+++ b/karld/loadump.py
@@ -10,8 +10,8 @@ from itertools import starmap
 from operator import itemgetter
 
 from karld.iter_utils import i_batch
-from karld.unicode_io import csv_to_unicode_reader
-from karld.unicode_io import get_unicode_row_writer
+from karld.unicode_io import csv_reader
+from karld.unicode_io import get_csv_row_writer
 
 LINE_BUFFER_SIZE = 5000
 FILE_BUFFER_SIZE = 10485760  # -1  # 419430400
@@ -45,7 +45,7 @@ def i_get_csv_data(file_name, *args, **kwargs):
     """
     buffering = kwargs.get('buffering', FILE_BUFFER_SIZE)
     with open(file_name, 'rb', buffering=buffering) as csv_file:
-        reader = csv_to_unicode_reader(csv_file, *args, **kwargs)
+        reader = csv_reader(csv_file, *args, **kwargs)
         for row in reader:
             yield row
 
@@ -69,11 +69,11 @@ def write_as_csv(items, file_name, append=False,
     else:
         mode = 'wtb'
     with open(file_name, mode, buffering=buffering) as csv_file:
-        unicode_row_writer = get_unicode_row_writer(csv_file)
+        write_row = get_csv_row_writer(csv_file)
         batches = i_batch(line_buffer_size, items)
         for batch in batches:
             for row in batch:
-                unicode_row_writer(row)
+                write_row(row)
 
 
 def is_file_csv(file_path_name):

--- a/karld/tests/test_unicode_io.py
+++ b/karld/tests/test_unicode_io.py
@@ -5,8 +5,8 @@ import unittest
 import cStringIO
 
 from karld.unicode_io import unicode_csv_unicode_reader
-from karld.unicode_io import csv_to_unicode_reader
-from karld.unicode_io import get_unicode_row_writer
+from karld.unicode_io import csv_reader
+from karld.unicode_io import get_csv_row_writer
 
 
 class TestUnicodeToUnicodeCSVReader(unittest.TestCase):
@@ -60,7 +60,7 @@ class TestCSVToUnicodeReader(unittest.TestCase):
         Ensure utf-8 strings in the data
         are converted to unicode sequences.
         """
-        rows = list(csv_to_unicode_reader(self.data))
+        rows = list(csv_reader(self.data))
 
         self.assertEqual(
             [
@@ -74,7 +74,7 @@ class TestCSVToUnicodeReader(unittest.TestCase):
         iteratively.
         """
         data = iter(self.data)
-        rows = csv_to_unicode_reader(data)
+        rows = csv_reader(data)
         first_row = next(rows)
         self.assertEqual([u"WĄŻ", u"utf-8 sample"],
                          first_row)
@@ -86,7 +86,7 @@ class TestCSVToUnicodeReader(unittest.TestCase):
 
 class TestUnicodeCSVRowWriter(unittest.TestCase):
     """
-    Ensure get_unicode_row_writer returns a function
+    Ensure get_csv_row_writer returns a function
     that will write a row of data to a stream.
     """
 
@@ -100,11 +100,11 @@ class TestUnicodeCSVRowWriter(unittest.TestCase):
 
     def test_write_unicode(self):
         """
-        Ensure the function returned from get_unicode_row_writer
+        Ensure the function returned from get_csv_row_writer
         will write a row to the io stream.
         """
 
-        unicode_row_writer = get_unicode_row_writer(self.file_stream)
+        unicode_row_writer = get_csv_row_writer(self.file_stream)
         for row in self.data:
             unicode_row_writer(row)
 


### PR DESCRIPTION
Unicode in the names is redundant
with the module name.

Revise the module doc

Improve the narrative, cut extraneous statements
